### PR TITLE
Update body-parser to version ^1.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "babel": "^6.5.2",
     "babel-preset-es2015-node5": "^1.1.2",
-    "body-parser": "^1.15.0",
+    "body-parser": "^1.15.1",
     "express": "^4.13.4",
     "express-graphql": "^0.4.9",
     "graphql": "^0.4.18"


### PR DESCRIPTION
#1.15.1 / 2016-05-06
- 1.15.1
- deps: bytes@2.3.0
- build: istanbul@0.4.3
- build: support Node.js 6.x
- tests: relax platform error message expectations
  fixes [#167](https://github.com/expressjs/body-parser/issues/167)
  closes [#168](https://github.com/expressjs/body-parser/issues/168)
- docs: clean up formatting of example titles
  closes [#169](https://github.com/expressjs/body-parser/issues/169)
- build: Node.js@5.11
- build: cache node_modules on Travis CI
- build: Node.js@5.9
- deps: type-is@~1.6.12
- deps: raw-body@~2.1.6
- build: Node.js@5.8
- build: Node.js@4.4
