### PR TITLE
Update express-graphql to version ^0.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "babel-preset-es2015-node5": "^1.1.2",
     "body-parser": "^1.15.0",
     "express": "^4.13.4",
-    "express-graphql": "^0.4.9",
+    "express-graphql": "^0.5.3",
     "graphql": "^0.4.18"
   },
   "devDependencies": {


### PR DESCRIPTION
#0.5.3 / 2016-05-27
- 0.5.3
- Merge pull request [#93](https://github.com/graphql/express-graphql/issues/93) from chentsulin/fix/module-export
  Close [#92](https://github.com/graphql/express-graphql/issues/92), avoid module.exports breaking change
- Close [#92](https://github.com/graphql/express-graphql/issues/92), avoid module.exports breaking change
