### PR TITLE
Update unexpected to version ^10.13.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "babel-core": "^6.5.2",
     "mocha": "^2.4.5",
-    "unexpected": "^10.8.2"
+    "unexpected": "^10.13.3"
   },
   "standard": {
     "globals": [


### PR DESCRIPTION
#10.13.3 / 2016-05-20
- 10.13.3
- Build unexpected.js
- Updated browser compatibility for now - will return to it
- Make sure that expect.use can handle function.name not being present on IE
- Don't hack the stack in environments that don't make the error stack available as a getter
- Merge pull request [#306](https://github.com/unexpectedjs/unexpected/issues/306) from unexpectedjs/feature/exposeStaticPromiseMethods
  Expose (almost) all of Bluebird's static methods.
- Only copy static Promise properties that are functions.
- Expose (almost) all of Bluebird's static methods.
- <object> to satisfy <object>: Skip missing keys expected to be missing so they don't get rendered in the diff.
- Merge pull request [#305](https://github.com/unexpectedjs/unexpected/issues/305) from unexpectedjs/feature/expectWithOneArgument
  Feature/expect with one argument
- Unsupport single-argument expect for the top-level expect.
- Cover top-level expect(..., expect.it(...))
- Increase coverage, fix error wording now that the 2nd expect parameter can be an expect.it.
- Increase mocha's default timeout, attempting to avoid timeouts with the external tests on Travis.
- Add support for expect(<subject>, expect.it(...))
- Replace makeAndMethod with addAdditionalPromiseMethods, reducing boilerplate.
- expect: Return a promise when passed only one argument.
