### PR TITLE
Update graphql to version ^0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "body-parser": "^1.15.0",
     "express": "^4.13.4",
     "express-graphql": "^0.4.9",
-    "graphql": "^0.4.18"
+    "graphql": "^0.6.0"
   },
   "devDependencies": {
     "babel-core": "^6.5.2",


### PR DESCRIPTION
#0.6.0 / 2016-05-11
- 0.6.0
- Validation: improving overlapping fields quality ([#386](https://github.com/graphql/graphql-js/issues/386))
  This improves the overlapping fields validation performance and improves error reporting quality by separating the concepts of checking fields "within" a single collection of fields from checking fields "between" two different collections of fields. This ensures for deeply overlapping fields that nested fields are not checked against each other repeatedly. Extending this concept further, fragment spreads are no longer expanded inline before looking for conflicts, instead the fields within a fragment are compared to the fields with the selection set which contained the referencing fragment spread.
  e.g.
  `graphql
  {
  same: a
  same: b
  ...X
  }
  fragment X on T {
  same: c
  same: d
  }
  `
  In the above example, the initial query body is checked "within" so `a` is compared to `b`. Also, the fragment `X` is checked "within" so `c` is compared to `d`. Because of the fragment spread, the query body and fragment `X` are checked "between" so that `a` and `b` are each compared to `c` and `d`. In this trivial example, no fewer checks are performed, but in the case where fragments are referenced multiple times, this reduces the overall number of checks (regardless of memoization).
  **BREAKING**: This can change the order of fields reported when a conflict arises when fragment spreads are involved. If you are checking the precise output of errors (e.g. for unit tests), you may find existing errors change from `"a" and "c" are different fields` to `"c" and "a" are different fields`.
  From a perf point of view, this is fairly minor as the memoization "PairSet" was already keeping these repeated checks from consuming time, however this will reduce the number of memoized hits because of the algorithm improvement.
  From an error reporting point of view, this reports nearest-common-ancestor issues when found in a fragment that comes later in the validation process. I've added a test which fails with the existing impl and now passes, as well as changed a comment.
  This also fixes an error where validation issues could be missed because of an over-eager memoization. I've also modified the `PairSet` to be aware of both forms of memoization, also represented by a previously failing test.
- Validation: context.getFragmentSpreads now accepts selectionSet rather than fragment AST node
- Factor out more closure functions
  Two more functions from the overlapping-fields validator which now accept arguments rather than closing over them locally.
- Factor out closure functions to normal functions
  The functions within this validator did not need to close over any state, which allows them to be pure functions.
- Deprecated directive ([#384](https://github.com/graphql/graphql-js/issues/384))
  This adds a new directive as part of the experimental schema language:
  `
  directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
  `
  It also adds support for this directive in the schemaPrinter and buildASTSchema.
  Additionally exports a new helper `specifiedDirectives` which is encoured to be used when addressing the collection of all directives defined by the spec. The `@deprecated` directive is optimistically added to this collection. While it's currently experimental, it will become part of the schema definition language RFC.
- RFC: Directive location: schema definition ([#382](https://github.com/graphql/graphql-js/issues/382))
  This allows directives to be defined on schema definitions.
- RFC: Schema Language Directives ([#376](https://github.com/graphql/graphql-js/issues/376))
  This implements adding directives to the experimental schema language by extending the _locations_ a directive can be used.
  Notice that this provides no semantic meaning to these directives - they are purely a mechanism for annotating an AST - however future directives which contain semantic meaning may be introduced in the future (the first will be `@deprecated`).
- Export introspection in public API
- Export directive definitions. ([#381](https://github.com/graphql/graphql-js/issues/381))
  This exports the ability to define new directives as well as access the built-in @skip and @include definitions.
- BUG: Ensure building AST schema does not exclude @skip and @include ([#380](https://github.com/graphql/graphql-js/issues/380))
  `buildASTSchema` used to not regard directives in 0.4.x, just always including only `@skip` and `@include`. Since 0.5.0 included the ability to use directives in the experimental schema language, existing use of this tool found no defined directives and therefore excluded these two built-ins.
  This fixes the issue by implicitly adding these built-in directives if they were not explicitly defined.
- documentation of schema constructor
- Revert "Remove all 'instanceof GraphQLSchema' checks" ([#377](https://github.com/graphql/graphql-js/issues/377))
- remove all 'instanceof GraphQLSchema' checks ([#371](https://github.com/graphql/graphql-js/issues/371))
- Error logging for new interface type semantics ([#350](https://github.com/graphql/graphql-js/issues/350))
- Nit: Missing case in grammar for TypeSystemDefinition in comment
- Bug: printer can print non-parsable value
  This fixes a bug where an empty "block" list could be skipped by the printer.
- Factor out suggestion quoting utility
- Minor refactoring
- Minor refactoring of error messages for unknown fields
- Include possible field, argument, type names when validation fails ([#355](https://github.com/graphql/graphql-js/issues/355))
  - Add suggestionList to return strings based on how simular they are to the input
  - Suggests valid fields in `FieldsOnCorrectType`
  - Suggest argument names
  - Suggested valid type names
  - Fix flow and unit test
  - addressed comments in PR: move file, update comment, filter out more options, remove redundant warning
  - fix typos
  - fix lint
- Tests
- Improve validation error message when field names conflict ([#363](https://github.com/graphql/graphql-js/issues/363))
  - Improve validation error message when field names conflict
  - Remove extra hint and add unit test
- tweak tests
- Deepen introspection query ([#364](https://github.com/graphql/graphql-js/issues/364))
- Remove unused fragment in queries in unit tests ([#367](https://github.com/graphql/graphql-js/issues/367))
- Update README.md
- Combine invariants into AST-aware error.
