### PR TITLE
Update mocha to version ^2.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "babel-core": "^6.5.2",
-    "mocha": "^2.4.5",
+    "mocha": "^2.5.3",
     "unexpected": "^10.8.2"
   },
   "standard": {


### PR DESCRIPTION
#2.5.3 / 2016-05-25
- Release v2.5.3
- Rebuild mocha.js
- Update CHANGELOG.md for v2.5.3 [ci skip]
- Make HTML reporter failure/passed links preventDefault to avoid SPA's hash navigation ([#2119](https://github.com/mochajs/mocha/issues/2119))
- Fix HTML reporter regression causing duplicate error output ([#2112](https://github.com/mochajs/mocha/issues/2112))
  Fixes [#2083](https://github.com/mochajs/mocha/issues/2083).
- avoid BitBucket rate-limiting when installing PhantomJS
